### PR TITLE
Add copyright header update workflow template

### DIFF
--- a/workflow-templates/copyright-update.properties.json
+++ b/workflow-templates/copyright-update.properties.json
@@ -1,0 +1,5 @@
+{
+  "name": "Copyright Update Workflow",
+  "description": "JHipster copyright update workflow template.",
+  "iconName": "copyright-update"
+}

--- a/workflow-templates/copyright-update.svg
+++ b/workflow-templates/copyright-update.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="118.41237mm"
+   height="142.93114mm"
+   viewBox="0 0 118.41237 142.93114"
+   version="1.1"
+   id="svg8">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(-44.473814,-68.441088)">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.5833px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="70.518951"
+       y="114.41651"
+       id="text835"><tspan
+         id="tspan833"
+         x="70.518951"
+         y="114.41651"
+         style="stroke-width:0.264583"></tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:190.068px;line-height:1.25;font-family:C059;-inkscape-font-specification:'C059, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#000000;fill-opacity:1;stroke:none;stroke-width:4.7517"
+       x="35.920753"
+       y="208.52121"
+       id="text839"><tspan
+         id="tspan837"
+         x="35.920753"
+         y="208.52121"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:190.068px;font-family:C059;-inkscape-font-specification:'C059, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;stroke-width:4.7517">C</tspan></text>
+  </g>
+</svg>

--- a/workflow-templates/copyright-update.yml
+++ b/workflow-templates/copyright-update.yml
@@ -1,0 +1,48 @@
+#
+# Copyright 2017-2021 the original author or authors from the JHipster project.
+#
+# This file is part of the JHipster project, see https://www.jhipster.tech/
+# for more information.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Copyright Update
+on:
+  schedule:
+    - cron: '0 0 31 12 *' # Repeats December 31st every year
+jobs:
+  pipeline:
+    name: copyright update
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    steps:
+      # Checkout
+      - uses: actions/checkout@v2
+
+      # Update the copyright headers
+      - name: Find and Replace
+        run: |
+          CURRENT_YEAR=$(date +'%Y')
+          NEW_YEAR=$(($CURRENT_YEAR + 1))
+          grep -rlZE "Copyright ([0-9]+)-$CURRENT_YEAR" . | xargs -0 sed -i -E "s/Copyright ([0-9]+)-$CURRENT_YEAR/Copyright \1-$NEW_YEAR/g"
+
+      # Create PR
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: 'feat: update copyright headers'
+          author: 'jhipster-bot <jhipster-bot@users.noreply.github.com>'
+          branch: 'copyright-date-update'
+          title: 'Update Copyright Headers'
+          body: 'This is an automated pull request to update the copyright headers'


### PR DESCRIPTION
Add the copyright header update workflow as a template so that every repo can import it.

Resolve https://github.com/jhipster/generator-jhipster/issues/13617